### PR TITLE
search in content pages AND multimedia by default

### DIFF
--- a/src/Components/SearchBar.php
+++ b/src/Components/SearchBar.php
@@ -63,6 +63,7 @@ class SearchBar extends Component {
 			) . ' action="' . $this->getSkinTemplate()->data[ 'wgScript' ] . '">' .
 
 			$this->indent( 1 ) . '<input type="hidden" name="title" value="' . $this->getSkinTemplate()->data[ 'searchtitle' ] . '" />' .
+                        $this->indent( 1 ) . '<input type="hidden" name="profile" value="all" />' .			
 			$this->indent() . '<div class="input-group">' .
 			$this->indent( 1 ) . $this->getSkinTemplate()->makeSearchInput( array( 'id' => IdRegistry::getRegistry()->getId( 'searchInput' ), 'type' => 'text', 'class' => 'form-control' ) ) .
 			$this->indent() . '<div class="input-group-btn">' .


### PR DESCRIPTION
Rationale:
As a user, I expect the search to return not only text matches, but also matches from files (like PDFs).

This change adds the "profile=all" parameter to the Special:Search call which then defaults to search "everything".